### PR TITLE
fix: Lint errors in the Goreleaser config.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,8 @@ builds:
     goarch: arm64
 
 archives:
-- format: tar.gz
+- formats:
+  - tar.gz
   # this name template makes the OS and Arch compatible with the results of `uname`.
   name_template: >-
     {{ .ProjectName }}_


### PR DESCRIPTION
This PR fixes the lint errors caused by the recent GoReleaser upgrade.