### PR TITLE
fix(build): Adds binaries for Linux/arm64.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,9 +15,6 @@ builds:
   goarch:
   - amd64
   - arm64
-  ignore:
-  - goos: linux
-    goarch: arm64
 
 archives:
 - formats:


### PR DESCRIPTION
This change updates the GoReleaser configuration to publish binaries for the LInux/arm64 platform. Those are used in Docker containers on ARM Macs.