### PR TITLE
fix: Clean up cached volatile refs in GitHub repos.

### DIFF
--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -248,6 +248,19 @@ func (loader *gitRepoChartLoader) loadRepositoryChart(
 		if err != nil {
 			return nil, err
 		}
+		if !isFixedGitReference(ref) {
+			// Non-fixed references like branches are not cacheable, so we should not
+			// leave the repository directory lying around.
+			defer func() {
+				if err = os.RemoveAll(repoPath); err != nil {
+					loader.logger.
+						With("repoPath", repoPath).
+						With("repoURL", repoURL).
+						With("error", err).
+						Error("Unable to clean up repository directory")
+				}
+			}()
+		}
 	}
 
 	chartPath := path.Join(repoPath, chartName)

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -77,14 +77,22 @@ func (loader *gitRepoChartLoader) cloneRepo(
 		normalizedGitRef.Commit,
 	)
 	// Git repositories checked out at different revisions should be cached at
-	// different paths in order to avoid cross revision contamination.
-	repoPath := path.Join(getCachePathForRepo(loader.cacheRoot, repoURL), gitRefString)
+	// different paths in order to avoid cross revision contamination and Git
+	// repositories checked at non-fixed references (e.g., branches) cannot be
+	// cached across program invocations and should be pushed into the ephemeral
+	// subdirectory.
+	repoPath := path.Join(
+		getCachePathForRepo(
+			loader.cacheRoot,
+			repoURL,
+			!isFixedGitReference((normalizedGitRef)),
+		),
+		gitRefString,
+	)
 
-	if isFixedGitReference(normalizedGitRef) {
-		if stat, err := os.Stat(repoPath); err == nil && stat.IsDir() {
-			loader.logger.Debug("Using cached Git repository")
-			return repoPath, nil
-		}
+	if stat, err := os.Stat(repoPath); err == nil && stat.IsDir() {
+		loader.logger.Debug("Using cached Git repository")
+		return repoPath, nil
 	}
 
 	parsedURL, err := url.Parse(repoURL)
@@ -247,19 +255,6 @@ func (loader *gitRepoChartLoader) loadRepositoryChart(
 		repoPath, err = loader.cloneRepo(&repo, repoURL)
 		if err != nil {
 			return nil, err
-		}
-		if !isFixedGitReference(ref) {
-			// Non-fixed references like branches are not cacheable, so we should not
-			// leave the repository directory lying around.
-			defer func() {
-				if err = os.RemoveAll(repoPath); err != nil {
-					loader.logger.
-						With("repoPath", repoPath).
-						With("repoURL", repoURL).
-						With("error", err).
-						Error("Unable to clean up repository directory")
-				}
-			}()
 		}
 	}
 

--- a/pkg/repository/helm.go
+++ b/pkg/repository/helm.go
@@ -100,7 +100,7 @@ func (loader *helmRepoChartLoader) loadRepositoryChart(
 	)
 	loader.logger.Debug("Loading chart from Helm repository")
 
-	repoPath := getCachePathForRepo(loader.cacheRoot, repoURL)
+	repoPath := getCachePathForRepo(loader.cacheRoot, repoURL, false)
 	getters := helmgetter.All(&cli.EnvSettings{})
 	chartRepo, err := helmrepo.NewChartRepository(
 		&helmrepo.Entry{

--- a/pkg/repository/oci.go
+++ b/pkg/repository/oci.go
@@ -243,7 +243,7 @@ func (loader *ociRepoChartLoader) loadRepositoryChart(
 		With("version", chartVersionSpec).
 		Debug("Loading chart from OCI Helm repository")
 
-	repoPath := getCachePathForRepo(loader.cacheRoot, repoURL)
+	repoPath := getCachePathForRepo(loader.cacheRoot, repoURL, false)
 	parsedURL, err := url.Parse(repoURL)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -313,6 +313,10 @@ func (mock *GitClientMock) Clone(
 	config repository.CloneConfig,
 ) (*git.Commit, error) {
 	args := mock.Called(ctx, repoURL, config)
+	result0 := args.Get(0)
+	if result0 == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*git.Commit), args.Error(1)
 }
 


### PR DESCRIPTION
#6 disabled GitHub repository caching when the repository reference is a branch. But the code would still leave a repository directory for such repositories, which would result in a failure to clone if the same repository with the same reference is encountered a second time, for a different chart. This PR enables reuse of cached directories for such repositories, but cleans them up after the command invocation completes.