### PR TITLE
feat: Implements recursive HelmRelease expansion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The following options are available:
 | --kube-version     | Kubernetes version to pass to charts in `.Capabilities.KubeVersion` |
 | --api-versions     | API version list (comma separated) to pass to charts in `.Capabilities.APIVersions` |
 | --chart-cache-dir  | A path to a directory with a persistent chart cache |
-
+| --max-expansions   | Maximum depth of recursive HelmRelease expansions to perform (when expansion produces `HelmRelease`:When resources) |
 
 #### Authentication
 
@@ -111,5 +111,4 @@ ssh://git@github.com/:
 
 ## Plans
 - Improve authentication support for Helm and OCI repositories.
-- Add recursive expansion of generated HelmRelease resources.
 - Expand the README content describing the program and its usage.

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -19,6 +19,7 @@ type ExpandCommandOptions struct {
 	credentialsFileName string
 	kubeVersion         string
 	apiVersions         []string
+	maxExpansions       int
 	chartCacheDir       string
 }
 
@@ -90,6 +91,7 @@ func NewExpandCommand(options *ExpandCommandOptions) *cobra.Command {
 					os.Stdout,
 					kubeVersion,
 					options.apiVersions,
+					options.maxExpansions,
 					options.chartCacheDir,
 					true,
 				)
@@ -119,6 +121,13 @@ func NewExpandCommand(options *ExpandCommandOptions) *cobra.Command {
 		"",
 		[]string{},
 		"Kubernetes api versions used for Capabilities.APIVersions in charts",
+	)
+	command.PersistentFlags().IntVarP(
+		&options.maxExpansions,
+		"max-expansions",
+		"",
+		1,
+		"Maximum number of expansions to perform recursively",
 	)
 	command.PersistentFlags().StringVarP(
 		&options.chartCacheDir,

--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -117,6 +117,7 @@ var _ = ginkgo.Describe("GitRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			"",
 			false,
 		)
@@ -222,6 +223,7 @@ var _ = ginkgo.Describe("GitRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			"",
 			true,
 		)
@@ -331,6 +333,7 @@ var _ = ginkgo.Describe("GitRepository expansion", func() {
 				output,
 				nil,
 				nil,
+				1,
 				cacheRoot,
 				false,
 			)
@@ -371,6 +374,7 @@ var _ = ginkgo.Describe("GitRepository expansion", func() {
 				output,
 				nil,
 				nil,
+				1,
 				cacheRoot,
 				false,
 			)
@@ -545,6 +549,7 @@ var _ = ginkgo.Describe("GitRepository expansion", func() {
 				output,
 				nil,
 				nil,
+				1,
 				cacheRoot,
 				false,
 			)
@@ -680,6 +685,7 @@ var _ = ginkgo.Describe("GitRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			"",
 			false,
 		)
@@ -835,6 +841,7 @@ var _ = ginkgo.Describe("GitRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			cacheRoot,
 			false,
 		)
@@ -914,6 +921,7 @@ var _ = ginkgo.Describe("GitRepository expansion", func() {
 			&bytes.Buffer{},
 			nil,
 			nil,
+			1,
 			"",
 			false,
 		)

--- a/pkg/repository/helm_test.go
+++ b/pkg/repository/helm_test.go
@@ -98,6 +98,7 @@ var _ = ginkgo.Describe("HelmRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			"",
 			false,
 		)
@@ -195,6 +196,7 @@ var _ = ginkgo.Describe("HelmRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			"",
 			true,
 		)
@@ -284,6 +286,7 @@ var _ = ginkgo.Describe("HelmRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			cacheRoot,
 			false,
 		)
@@ -313,6 +316,7 @@ var _ = ginkgo.Describe("HelmRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			cacheRoot,
 			false,
 		)

--- a/pkg/repository/oci_test.go
+++ b/pkg/repository/oci_test.go
@@ -133,6 +133,7 @@ var _ = ginkgo.Describe("OCIRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			"",
 			false,
 		)
@@ -228,6 +229,7 @@ var _ = ginkgo.Describe("OCIRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			"",
 			true,
 		)
@@ -318,6 +320,7 @@ var _ = ginkgo.Describe("OCIRepository expansion", func() {
 			io.Discard,
 			nil,
 			nil,
+			1,
 			cacheRoot,
 			false,
 		)
@@ -352,6 +355,7 @@ var _ = ginkgo.Describe("OCIRepository expansion", func() {
 			output,
 			nil,
 			nil,
+			1,
 			cacheRoot,
 			false,
 		)

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -592,7 +592,6 @@ type releaseRepoRenderer struct {
 	chartCacheDir     string
 	chartCache        map[string]*chart.Chart
 	credentials       Credentials
-	pairs             *[]releaseRepo
 }
 
 func newReleaseRepoRenderer(


### PR DESCRIPTION
This PR implements support for recursively invoking expansion on the expansion results. That is, if a chart generates a `HelmRelease` manifest, a second invocation will expand it, obtaining the final resource manifests.