### PR TITLE
chore: Refactors git reference normalization.

### DIFF
--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -31,15 +31,10 @@ func newGitRepositoryLoader(config loaderConfig) repositoryLoader {
 func normalizeGitReference(
 	original *sourcev1.GitRepositoryRef,
 ) *sourcev1.GitRepositoryRef {
-	if original != nil &&
-		(original.Branch != "" ||
-			original.Tag != "" ||
-			original.SemVer != "" ||
-			original.Name != "" ||
-			original.Commit != "") {
-		return original
+	if (original == nil || *original == sourcev1.GitRepositoryRef{}) {
+		return &sourcev1.GitRepositoryRef{Branch: "master"}
 	}
-	return &sourcev1.GitRepositoryRef{Branch: "master"}
+	return original
 }
 
 // Refer to GitRepositoryRef description in


### PR DESCRIPTION
This is a small change to make the Git reference comparison in the reference normalization function shorter and more readable.