### PR TITLE
fix: Fixes ECR repository detection in subcharts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 dist/
+fouskoti


### PR DESCRIPTION
This PR fixes detection of ECR repositories for charts referred to as parts of other charts. If such a chart is in an ECR repository, we need to perform an AWS login procedure for it.

Best viewed with whitespace diff [suppressed](https://github.com/sageailabs/fouskoti/pull/16/files?w=1).