### PR TITLE
fix: Fix chart in-memory cache corruption from shared pointer mutation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sageailabs/fouskoti
 
-go 1.25.6
+go 1.26.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/pkg/repository/helm_test.go
+++ b/pkg/repository/helm_test.go
@@ -342,4 +342,137 @@ var _ = ginkgo.Describe("HelmRepository expansion", func() {
 			gomega.Equal(chartFiles["templates/configmap.yaml"]))
 	})
 
+	ginkgo.It("does not corrupt cached dependency chart parent pointer when used standalone", func() {
+		repoRoot, err := os.MkdirTemp("", "")
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		defer os.RemoveAll(repoRoot)
+		server, port, serverDone, err := serveDirectory(repoRoot, logger, nil)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// dep-chart is used as a dependency of wrapper-chart AND also
+		// expanded standalone. Both reference the same Helm repo version so
+		// they share a cache key.
+		depChartFiles := map[string]string{
+			"Chart.yaml": strings.Join([]string{
+				"apiVersion: v2",
+				"name: dep-chart",
+				"version: 0.1.0",
+			}, "\n"),
+			"values.yaml": "data:\n  key: default",
+			"templates/configmap.yaml": strings.Join([]string{
+				"apiVersion: v1",
+				"kind: ConfigMap",
+				"metadata:",
+				"  namespace: {{ .Release.Namespace }}",
+				"  name: {{ .Release.Name }}-dep-configmap",
+				"data: {{- .Values.data | toYaml | nindent 2 }}",
+			}, "\n"),
+		}
+
+		wrapperChartFiles := map[string]string{
+			"Chart.yaml": strings.Join([]string{
+				"apiVersion: v2",
+				"name: wrapper-chart",
+				"version: 0.1.0",
+				"dependencies:",
+				"- name: dep-chart",
+				fmt.Sprintf("  repository: http://localhost:%d", port),
+				"  version: 0.1.0",
+			}, "\n"),
+			"values.yaml": "wrapper: true",
+			"templates/configmap.yaml": strings.Join([]string{
+				"apiVersion: v1",
+				"kind: ConfigMap",
+				"metadata:",
+				"  namespace: {{ .Release.Namespace }}",
+				"  name: {{ .Release.Name }}-wrapper-configmap",
+				"data:",
+				"  wrapper: \"true\"",
+			}, "\n"),
+		}
+
+		err = createChartArchiveInDir("dep-chart", "0.1.0", depChartFiles, repoRoot)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		err = createChartArchiveInDir("wrapper-chart", "0.1.0", wrapperChartFiles, repoRoot)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		err = indexRepository(repoRoot, port)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// wrapper-release loads dep-chart as a dependency (sets parent).
+		// standalone-release loads dep-chart directly.
+		// Without the fix, the cache returns dep-chart with parent=wrapper-chart
+		// causing template paths like wrapper-chart/charts/dep-chart/...
+		input := strings.Join([]string{
+			"apiVersion: helm.toolkit.fluxcd.io/v2",
+			"kind: HelmRelease",
+			"metadata:",
+			"  namespace: testns",
+			"  name: wrapper-release",
+			"spec:",
+			"  chart:",
+			"    spec:",
+			"      chart: wrapper-chart",
+			"      version: 0.1.0",
+			"      sourceRef:",
+			"        kind: HelmRepository",
+			"        name: local",
+			"---",
+			"apiVersion: helm.toolkit.fluxcd.io/v2",
+			"kind: HelmRelease",
+			"metadata:",
+			"  namespace: testns",
+			"  name: standalone-release",
+			"spec:",
+			"  chart:",
+			"    spec:",
+			"      chart: dep-chart",
+			"      version: 0.1.0",
+			"      sourceRef:",
+			"        kind: HelmRepository",
+			"        name: local",
+			"  values:",
+			"    data:",
+			"      key: standalone",
+			"---",
+			"apiVersion: source.toolkit.fluxcd.io/v1",
+			"kind: HelmRepository",
+			"metadata:",
+			"  namespace: testns",
+			"  name: local",
+			"spec:",
+			fmt.Sprintf("  url: http://localhost:%d", port),
+		}, "\n")
+
+		expander := NewHelmReleaseExpander(ctx, logger, nil, nil)
+		output := &bytes.Buffer{}
+		err = expander.ExpandHelmReleases(
+			Credentials{},
+			bytes.NewBufferString(input),
+			output,
+			nil,
+			nil,
+			nil,
+			1,
+			"",
+			true,
+		)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		err = stopServing(server, serverDone)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		result := output.String()
+		// Standalone expansion must use dep-chart template paths, NOT
+		// wrapper-chart/charts/dep-chart paths.
+		g.Expect(result).To(gomega.ContainSubstring(
+			"# Source: dep-chart/templates/configmap.yaml",
+		))
+		g.Expect(result).To(gomega.ContainSubstring(
+			"name: testns-standalone-release-dep-configmap",
+		))
+		// Wrapper expansion must also produce its own dependency output.
+		g.Expect(result).To(gomega.ContainSubstring(
+			"name: testns-wrapper-release-wrapper-configmap",
+		))
+	})
+
 })

--- a/pkg/repository/helm_test.go
+++ b/pkg/repository/helm_test.go
@@ -471,6 +471,13 @@ var _ = ginkgo.Describe("HelmRepository expansion", func() {
 		))
 		// Wrapper expansion must also produce its own dependency output.
 		g.Expect(result).To(gomega.ContainSubstring(
+			"# Source: wrapper-chart/charts/dep-chart/templates/configmap.yaml",
+		))
+		g.Expect(result).To(gomega.ContainSubstring(
+			"name: testns-wrapper-release-dep-configmap",
+		))
+		// And the wrapper chart's own templates should still render.
+		g.Expect(result).To(gomega.ContainSubstring(
 			"name: testns-wrapper-release-wrapper-configmap",
 		))
 	})

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -195,6 +195,32 @@ func decodeToObject(node *yaml.RNode, out runtime.Object) error {
 	return nil
 }
 
+// copyChart creates a copy of a chart with its own Metadata and dependency
+// slice, so that ProcessDependencies mutations don't corrupt the in-memory cache.
+func copyChart(src *chart.Chart) *chart.Chart {
+	cpy := *src
+
+	// Deep-copy Metadata since ProcessDependencies mutates
+	// Metadata.Dependencies (removes disabled entries, flips Enabled flags).
+	if src.Metadata != nil {
+		md := *src.Metadata
+		if md.Dependencies != nil {
+			deps := make([]*chart.Dependency, len(md.Dependencies))
+			for i, d := range md.Dependencies {
+				dd := *d
+				deps[i] = &dd
+			}
+			md.Dependencies = deps
+		}
+		cpy.Metadata = &md
+	}
+
+	// Copy the runtime dependency slice so SetDependencies on the copy
+	// doesn't affect the cached original.
+	cpy.SetDependencies(src.Dependencies()...)
+	return &cpy
+}
+
 func getCachePathForRepo(cacheRoot string, repoURL string, ephemeral bool) string {
 	urlPath := strings.ReplaceAll(strings.TrimSuffix(repoURL, "/"), "/", "#")
 	parts := []string{cacheRoot}
@@ -350,7 +376,7 @@ func loadChartDependencies(
 				err,
 			)
 		}
-		parentChart.AddDependency(dependencyChart)
+		parentChart.AddDependency(copyChart(dependencyChart))
 	}
 	return nil
 }

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -195,8 +195,9 @@ func decodeToObject(node *yaml.RNode, out runtime.Object) error {
 	return nil
 }
 
-// copyChart creates a copy of a chart with its own Metadata and dependency
-// slice, so that ProcessDependencies mutations don't corrupt the in-memory cache.
+// copyChart creates a deep copy of a chart with its own Metadata, dependency
+// slice, and recursively copied dependency charts, so that mutations like
+// ProcessDependencies and AddDependency don't corrupt the in-memory cache.
 func copyChart(src *chart.Chart) *chart.Chart {
 	cpy := *src
 
@@ -215,9 +216,14 @@ func copyChart(src *chart.Chart) *chart.Chart {
 		cpy.Metadata = &md
 	}
 
-	// Copy the runtime dependency slice so SetDependencies on the copy
-	// doesn't affect the cached original.
-	cpy.SetDependencies(src.Dependencies()...)
+	// Recursively copy each dependency chart so that nested mutations
+	// (e.g., parent pointer changes, recursive ProcessDependencies) don't
+	// leak back into the cached originals.
+	copiedDeps := make([]*chart.Chart, len(src.Dependencies()))
+	for i, dep := range src.Dependencies() {
+		copiedDeps[i] = copyChart(dep)
+	}
+	cpy.SetDependencies(copiedDeps...)
 	return &cpy
 }
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -208,8 +208,7 @@ func copyChart(src *chart.Chart) *chart.Chart {
 		if md.Dependencies != nil {
 			deps := make([]*chart.Dependency, len(md.Dependencies))
 			for i, d := range md.Dependencies {
-				dd := *d
-				deps[i] = &dd
+				deps[i] = new(*d)
 			}
 			md.Dependencies = deps
 		}


### PR DESCRIPTION
This pull request addresses a bug where the in-memory Helm chart cache could be corrupted when the same dependency chart is used both as a dependency and as a standalone chart. The main fix is to ensure that charts loaded from the cache are deep-copied before being mutated, preventing unintended side effects between releases. A new test is also added to verify this behavior.

**Bug fix for chart cache mutation:**

* Added a `copyChart` function in `pkg/repository/repository.go` to deep-copy Helm charts, including their metadata and dependencies, before any mutations are performed. This prevents mutations (such as those done by `ProcessDependencies`) from affecting cached charts shared across releases.
* Updated `loadChartDependencies` to use `copyChart` when adding dependencies to a parent chart, ensuring the cached dependency is not mutated.

**Testing improvements:**

* Added a new test case in `pkg/repository/helm_test.go` to verify that expanding a dependency chart both as a dependency and as a standalone chart does not corrupt the cache or parent pointers. The test ensures template paths and output are correct for both scenarios.